### PR TITLE
allow paths with leading '/'

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -47,7 +47,7 @@ class PyWebHdfsClient(object):
         """
         Creates a new file on HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
         :param file_data: the initial data to write to the new file
 
         The function wraps the WebHDFS REST call:
@@ -108,7 +108,7 @@ class PyWebHdfsClient(object):
         """
         Appends to an existing file on HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
         :param file_data: data to append to existing file
 
         The function wraps the WebHDFS REST call:
@@ -164,7 +164,7 @@ class PyWebHdfsClient(object):
         """
         Reads from a file on HDFS  and returns the content
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
 
         The function wraps the WebHDFS REST call:
 
@@ -199,7 +199,7 @@ class PyWebHdfsClient(object):
         """
         Create a new directory on HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
 
         The function wraps the WebHDFS REST call:
 
@@ -232,7 +232,7 @@ class PyWebHdfsClient(object):
         """
         Rename an existing directory or file on HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
         :param destination_path: the new file path name
 
         The function wraps the WebHDFS REST call:
@@ -261,7 +261,7 @@ class PyWebHdfsClient(object):
         """
         Delete an existing file or directory from HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
 
         The function wraps the WebHDFS REST call:
 
@@ -292,7 +292,7 @@ class PyWebHdfsClient(object):
         """
         Get the file_status of a single file or directory on HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
 
         The function wraps the WebHDFS REST call:
 
@@ -349,7 +349,7 @@ class PyWebHdfsClient(object):
         """
         Get the content summary of a directory on HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
 
         The function wraps the WebHDFS REST call:
 
@@ -384,7 +384,7 @@ class PyWebHdfsClient(object):
         """
         Get the file_checksum of a single file on HDFS
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
 
         The function wraps the WebHDFS REST call:
 
@@ -416,7 +416,7 @@ class PyWebHdfsClient(object):
         Get a list of file_status for all files and directories
         inside an HDFS directory
 
-        :param path: the HDFS file path without a leading '/'
+        :param path: the HDFS file path
 
         The function wraps the WebHDFS REST call:
 
@@ -472,7 +472,8 @@ class PyWebHdfsClient(object):
         the <PATH>, <OPERATION>, and any provided optional arguments
         """
 
-        path_param = quote(path.encode('utf8'))
+        no_root_path = (path[1:] if path[0] == '/' else path)
+        path_param = quote(no_root_path.encode('utf8'))
 
         # setup the parameter represent the WebHDFS operation
         operation_param = '?op={operation}'.format(operation=operation)

--- a/tests/test_webhdfs.py
+++ b/tests/test_webhdfs.py
@@ -490,6 +490,12 @@ class WhenTestingCreateUri(unittest.TestCase):
                                           mykey=myval)
         self.assertEqual(uri, result)
 
+    def test_create_uri_with_leading_slash(self):
+        op = operations.CREATE
+        uri_path_no_slash = self.webhdfs._create_uri(self.path, op)
+        uri_path_with_slash = self.webhdfs._create_uri('/' + self.path, op)
+        self.assertEqual(uri_path_no_slash, uri_path_with_slash)
+
     def test_create_uri_with_unicode_path(self):
         op = operations.CREATE
         mykey = 'mykey'


### PR DESCRIPTION
To make the module more user friendly, it would be nice to allow paths like `/tmp/foo/bar`, not only `tmp/foo/bar`.