### PR TITLE
added exists_file_dir

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -466,6 +466,33 @@ class PyWebHdfsClient(object):
 
         return response.json()
 
+    def exists_file_dir(self, path):
+        """
+        Checks whether a file or directory exists on HDFS
+
+        :param path: the HDFS file path
+
+        The function wraps the WebHDFS REST call:
+
+        GET http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=GETFILESTATUS
+
+        and returns a bool based on the response.
+
+        Example for checking whether a file exists:
+
+        >>> hdfs = PyWebHdfsClient(host='host',port='50070', user_name='hdfs')
+        >>> my_file = 'user/hdfs/data/myfile.txt'
+        >>> hdfs.exists_file_dir(my_file)
+        True
+        """
+        response = self._resolve_host(requests.get, True,
+                                      path, operations.GETFILESTATUS)
+        if response.status_code == http_client.OK:
+            return True
+        elif response.status_code == http_client.NOT_FOUND:
+            return False
+        _raise_pywebhdfs_exception(response.status_code, response.content)
+
     def _create_uri(self, path, operation, **kwargs):
         """
         internal function used to construct the WebHDFS request uri based on

--- a/tests/test_webhdfs.py
+++ b/tests/test_webhdfs.py
@@ -457,6 +457,58 @@ class WhenTestingListDirOperation(unittest.TestCase):
             self.assertEqual(result[key], self.file_status[key])
 
 
+class WhenTestingFileExistsOperation(unittest.TestCase):
+
+    def setUp(self):
+
+        self.host = 'hostname'
+        self.port = '00000'
+        self.user_name = 'username'
+        self.webhdfs = PyWebHdfsClient(host=self.host, port=self.port,
+                                       user_name=self.user_name)
+        self.response = MagicMock()
+        self.requests = MagicMock(return_value=self.response)
+        self.path = 'user/hdfs/old_dir'
+        self.response = MagicMock()
+        self.file_status = {
+            "FileStatus": {
+                "accessTime": 0,
+                "blockSize": 0,
+                "group": "supergroup",
+                "length": 0,
+                "modificationTime": 1320173277227,
+                "owner": "webuser",
+                "pathSuffix": "",
+                "permission": "777",
+                "replication": 0,
+                "type": "DIRECTORY"
+            }
+        }
+        self.response.json = MagicMock(return_value=self.file_status)
+
+    def test_exists_throws_exception_for_error(self):
+
+        self.response.status_code = http_client.BAD_REQUEST
+        self.requests.get.return_value = self.response
+        with patch('pywebhdfs.webhdfs.requests', self.requests):
+            with self.assertRaises(errors.PyWebHdfsException):
+                self.webhdfs.exists_file_dir(self.path)
+
+    def test_exists_returns_true(self):
+
+        self.response.status_code = http_client.OK
+        self.requests.get.return_value = self.response
+        with patch('pywebhdfs.webhdfs.requests', self.requests):
+            self.assertTrue(self.webhdfs.exists_file_dir(self.path))
+
+    def test_exists_returns_false(self):
+
+        self.response.status_code = http_client.NOT_FOUND
+        self.requests.get.return_value = self.response
+        with patch('pywebhdfs.webhdfs.requests', self.requests):
+            self.assertFalse(self.webhdfs.exists_file_dir(self.path))
+
+
 class WhenTestingCreateUri(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
I added a convenience method for a common operation, so that the user can write this

    exists = hdfs.exists_file_dir(path)

instead of

    try:
        hdfs.get_file_dir_status(path)
        exists = True
    except FileNotFound:
        exists = False