### PR TITLE
Set default timeout to None instead of 0

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -20,7 +20,7 @@ class PyWebHdfsClient(object):
     """
 
     def __init__(self, host='localhost', port='50070', user_name=None,
-                 path_to_hosts=None, timeout=0):
+                 path_to_hosts=None, timeout=None):
         """
         Create a new client for interacting with WebHDFS
 


### PR DESCRIPTION
Set default timeout to None instead of 0

This fixes the issue #31, implementing the suggestion by @mocsar.

----

I copy the reported issue here:

The following error occures after upgarding to 0.4.0:

```
Traceback (most recent call last):
  ...
  File "/usr/lib/python2.7/site-packages/pywebhdfs/webhdfs.py", line 344, in get_file_dir_status
    path, operations.GETFILESTATUS)
  File "/usr/lib/python2.7/site-packages/pywebhdfs/webhdfs.py", line 689, in _resolve_host
    timeout=self.timeout)
  File "/usr/lib/python2.7/site-packages/requests/api.py", line 69, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/api.py", line 50, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 465, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', error(119, 'Operation now in progress'))
```

The default timeout of requests is None so it would be better to use None instead of 0:

```
class PyWebHdfsClient(object):
    pass

    def __init__(self, host='localhost', port='50070', user_name=None,
                 path_to_hosts=None, timeout=None):
        pass
```
