### PR TITLE
Added support for general base URIs and extra options for REST requests.

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -45,11 +45,13 @@ class PyWebHdfsClient(object):
         >>>                         'auth': ('username', 'password')})
         """
 
+        self.host = host
+        self.port = port
         self.user_name = user_name
         self.timeout = timeout
         self.path_to_hosts = path_to_hosts
         if self.path_to_hosts is None:
-            self.path_to_hosts = [('.*', [host])]
+            self.path_to_hosts = [('.*', [self.host])]
 
         self.base_uri_pattern = base_uri_pattern.format(
             host="{host}", port=port)

--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -22,7 +22,7 @@ class PyWebHdfsClient(object):
     def __init__(self, host='localhost', port='50070', user_name=None,
                  path_to_hosts=None, timeout=None,
                  base_uri_pattern="http://{host}:{port}/webhdfs/v1/",
-                 request_extra_opts=None):
+                 request_extra_opts={}):
         """
         Create a new client for interacting with WebHDFS
 


### PR DESCRIPTION
A Knox gateway (common in HortonWorks HDP clusters) can serve as a proxy
for WebHDFS, but the base URI has a few more components.

In a secure cluster, WebHDFS and Knox gateways use SSL.  You can do this
by using "https" as the protocol in the base URI.  If the certificate
is self-signed or signed by an internal CA, you'll get SSL errors from
the Python `requests` library unless you either turn off SSL validation
(pass in `verify=False` to each `requests` call) or set the path to your
internal CA (`verify="/my/root/CA.crt"`).  If Kerberos is enabled in the
cluster, you also need to pass in HTTP authentication headers to Knox.
Both of these can now be done by passing in a dictionary of "extra options"
for the underlying `requests` calls in `PyWebHDFSClient.__init__()`.

I've tested these against a live SSL-enabled Knox gateway that proxies
into a Kerberised Hadoop cluster and it works as expected.