### PR TITLE
Check whether configured namenodes are up before continuing with CRUD operations

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -698,13 +698,16 @@ class PyWebHdfsClient(object):
         hosts = self._resolve_federation(path)
         for host in hosts:
             uri = uri_without_host.format(host=host)
-            response = req_func(uri, allow_redirects=allow_redirect,
-                                timeout=self.timeout,
-                                **self.request_extra_opts)
+            try:
+                response = req_func(uri, allow_redirects=allow_redirect,
+                                    timeout=self.timeout,
+                                    **self.request_extra_opts)
 
-            if not _is_standby_exception(response):
-                _move_active_host_to_head(hosts, host)
-                return response
+                if not _is_standby_exception(response):
+                    _move_active_host_to_head(hosts, host)
+                    return response
+            except requests.exceptions.RequestException:
+                continue
         raise errors.ActiveHostNotFound(msg="Could not find active host")
 
 


### PR DESCRIPTION
Currently, if a namenode in an HA setup is down and is listed first in the `path_to_hosts`, pywebhdfs will try to connect to it and fail. The only thing that is checked is whether or not the namenode is a standby state. If it's not, it is assumed to be the active namenode (which is an incorrect assumption as proven by the above situation).

This change simply tries to connect to the designated namenode in the `_resolve_host` function, and if it cannot, does not promote it to the top of the hosts list. If there are no active namenodes (i.e. no namenodes that are not either down or in a standby state), then the `errors.ActiveHostNotFound` error is raised and program execution will halt. This is the expected behaviour.
