### PR TITLE
Set default timeout of 2 minutes for all requests

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -20,7 +20,7 @@ class PyWebHdfsClient(object):
     """
 
     def __init__(self, host='localhost', port='50070', user_name=None,
-                 path_to_hosts=None, timeout=None,
+                 path_to_hosts=None, timeout=120,
                  base_uri_pattern="http://{host}:{port}/webhdfs/v1/",
                  request_extra_opts={}):
         """
@@ -30,7 +30,7 @@ class PyWebHdfsClient(object):
         :param port: the port number for WebHDFS on the namenode
         :param user_name: WebHDFS user.name used for authentication
         :param path_to_hosts: mapping paths to hostnames for federation
-        :param timeout: timeout for the underlying HTTP request
+        :param timeout: timeout for the underlying HTTP request (def: 120 sec)
         :param base_uri_pattern: format string for base URI
         :param request_extra_opts: dictionary of extra options to pass
           to the requests library (e.g., SSL, HTTP authentication, etc.)

--- a/tests/test_webhdfs.py
+++ b/tests/test_webhdfs.py
@@ -17,6 +17,7 @@ class WhenTestingPyWebHdfsConstructor(unittest.TestCase):
         self.assertEqual('localhost', webhdfs.host)
         self.assertEqual('50070', webhdfs.port)
         self.assertIsNone(webhdfs.user_name)
+        self.assertEqual(120, webhdfs.timeout)
 
     def test_init_args_provided(self):
         host = '127.0.0.1'


### PR DESCRIPTION
- If there is no timeout, the underlying request will hang
  indefinitely. This can cause problems if a namenode is hung but has
  failed over to a secondary/backup.
- This could also be reflected in the docs that without a timeout your
  application could hang indefinitely, but I think it might be better
  to explictly set a default for users who may not read the docs.