### PR TITLE
Add safety when moving active host to head of list

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -781,5 +781,7 @@ def _move_active_host_to_head(hosts, active_host):
     """
     to improve efficiency move active host to head
     """
-    hosts.remove(active_host)
-    hosts.insert(0, active_host)
+    _hosts = [h for h in hosts]
+    _hosts.remove(active_host)
+    _hosts.insert(0, active_host)
+    hosts = _hosts


### PR DESCRIPTION
- Potential for "concurrent" access failures between the active host
  removal and re-add to the front of the list. It is much safer to create
  a new object and then do the ol' Indiana Jones idol replacement